### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Reservator
 ==========
 
+!['Reservator in its natural habitat' photo](http://i.imgur.com/xd1xi09.jpg)
+*Reservator in its natural habitat*
+
 Description
 -----------
 Reservator is an Android application for displaying and reserving meeting rooms. The application uses Google’s resources as meeting rooms. If you want to add a room to the application, you have to create a calendar for your resource and sync your account with the tablet. See help for sharing resources at https://support.google.com/a/answer/1034381?hl=en. You can also find help for creating calendars for shared resources at https://support.google.com/calendar/answer/34584?hl=en. We recommend setting up a unique Google account for the tablet itself.
@@ -9,7 +12,10 @@ This application is meant for tablets so there are a few layout problems when us
 
 Background
 ----------
-This application was created as an internal project for <a href="http://www.futurice.com">Futurice's</a> office in Helsinki and nowadays it is used at every <a href="http://www.futurice.com">Futurice</a> office. It was open sourced as a part of the <a href="http://blog.futurice.com/summer-of-love-of-open-source">Summer of Love program</a>.
+This application was created as an internal project for <a href="http://www.futurice.com">Futurice's</a> office in Helsinki and nowadays it is used at every Futurice office. It was open sourced as a part of the <a href="http://blog.futurice.com/summer-of-love-of-open-source">Summer of Love program</a>.
+
+Reservator is now [available for free on Google Play](https://play.google.com/store/apps/details?id=com.futurice.android.reservator),
+and we've [written about it in Futurice blog](http://blog.futurice.com/reservator) too.
 
 About Futurice
 --------------


### PR DESCRIPTION
- Add 'Reservator in its natural habitat' photo to make the purpose of the app immediately clear.
- Also link to the Reservator blog post and Google Play entry.
- Tweak: clean up redundant linking.
