### PR TITLE
Highlights the default room that was set in the settings

### DIFF
--- a/app/src/main/java/com/futurice/android/reservator/view/LobbyReservationRowView.java
+++ b/app/src/main/java/com/futurice/android/reservator/view/LobbyReservationRowView.java
@@ -5,6 +5,7 @@ import android.app.AlertDialog.Builder;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
+import android.graphics.Typeface;
 import android.os.AsyncTask;
 import android.util.AttributeSet;
 import android.view.View;
@@ -17,6 +18,7 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.AutoCompleteTextView;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.ViewSwitcher;
 import android.content.SharedPreferences;
@@ -39,6 +41,7 @@ public class LobbyReservationRowView extends FrameLayout implements
     AutoCompleteTextView nameField;
     CustomTimeSpanPicker2 timePicker2;
     TextView roomNameView, roomInfoView, roomStatusView;
+    ImageView defaultRoomFlag;
     ReservatorApplication application;
     ViewSwitcher modeSwitcher;
     OnReserveListener onReserveCallback = null;
@@ -83,6 +86,8 @@ public class LobbyReservationRowView extends FrameLayout implements
         roomInfoView = (TextView) findViewById(R.id.roomInfoLabel);
         roomStatusView = (TextView) findViewById(R.id.roomStatusLabel);
         modeSwitcher = (ViewSwitcher) findViewById(R.id.modeSwitcher);
+        defaultRoomFlag = (ImageView) findViewById(R.id.roomDefaultIcon);
+
         switchToNormalModeContent();
         settings = context.getSharedPreferences(context.getString(R.string.PREFERENCES_NAME), context.MODE_PRIVATE);
 
@@ -118,6 +123,7 @@ public class LobbyReservationRowView extends FrameLayout implements
 
         // Room stuff
         roomNameView.setText(room.getName());
+
         if (room.getCapacity() >= 0) {
             roomInfoView.setText("for " + room.getCapacity());
         } else {
@@ -145,6 +151,15 @@ public class LobbyReservationRowView extends FrameLayout implements
             roomStatusView.setTextColor(getResources().getColor(
                 R.color.StatusReservedColor));
             bookNowButton.setVisibility(View.INVISIBLE);
+        }
+
+        if(application.getFavouriteRoomName().equals(room.getName()))
+        {
+            defaultRoomFlag.setVisibility(VISIBLE);
+            roomNameView.setTypeface(null, Typeface.BOLD);
+        } else {
+            defaultRoomFlag.setVisibility(INVISIBLE);
+            roomNameView.setTypeface(null, Typeface.NORMAL);
         }
     }
 

--- a/app/src/main/res/layout/lobby_reservation_row.xml
+++ b/app/src/main/res/layout/lobby_reservation_row.xml
@@ -21,6 +21,13 @@
             android:layout_gravity="center_vertical"
             android:orientation="horizontal">
 
+            <ImageView
+                android:id="@+id/roomDefaultIcon"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:src="@android:drawable/ic_notification_overlay"
+                android:layout_marginRight="4dp"></ImageView>
+
 
             <LinearLayout
                 android:id="@+id/titleLayout"


### PR DESCRIPTION
This commit fixes #39 

![screen](https://cloud.githubusercontent.com/assets/279378/20137333/741dd92e-a682-11e6-89f9-faffb65b741c.png)

Just a small disclaimer: If there is no room capacity set, the icon will seem just a bit unaligned. I'd be interested in redesigning the `LobbyActivity` anyways though with a separate pull request (also replacing the deprecated `DigitalClock`).

